### PR TITLE
feat(status_bar): migrate to native winbar implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+orchestrator.nvim is a Neovim plugin for orchestrating AI agent terminal workflows with Claude Code. It provides a floating prompt editor for composing multi-line prompts, manages multiple Claude Code terminal instances per project, and displays a visual status bar showing active instances.
+
+## Development Commands
+
+```bash
+# Reload plugin during development (preserves running Claude instances)
+:OrchestratorReload
+
+# Debug plugin state
+:OrchestratorDebug
+
+# Test teardown (cleans up all state)
+:lua require("orchestrator").teardown()
+```
+
+## Architecture
+
+### Module Dependency Flow
+
+```
+init.lua (entry point, public API, setup)
+    ├── state.lua (centralized state - no dependencies)
+    ├── highlights.lua (color palette, highlight groups)
+    ├── instances.lua (instance tracking) ─── requires state, highlights
+    ├── status_bar.lua (winbar status bar) ─── requires state, highlights, instances
+    ├── picker.lua (vim.ui.select wrapper) ─── requires instances, highlights, state
+    ├── editor.lua (floating prompt editor) ─── requires state
+    └── terminal.lua (spawn/focus/kill) ─── no direct requires
+```
+
+### Breaking Circular Dependencies
+
+The plugin uses setter injection to avoid circular dependencies between modules. In `init.lua` setup():
+- `instances.set_status_bar(status_bar)` - instances notifies status_bar on changes
+- `terminal.set_instances(instances)` - terminal registers spawned instances
+- `picker.set_terminal(terminal)` - picker spawns new terminals
+- `editor.set_send_function(M.send_to_terminal)` - editor sends prompts to init's orchestration function
+
+### State Management
+
+All plugin state is centralized in `state.lua` via `M.state`:
+- `editor` - Window ID, tabs array (`{buf, name}`), current tab index
+- `status_bar` - Visibility flag only (winbar is per-window, no central window/buffer)
+- `claude_instances` - Array of instance objects with buf, job_id, color_idx, cwd, spawn_type, spawned_at
+- `next_color_idx` - Rotating 1-8 color assignment
+- `last_active_buf` - Tracks last focused Claude terminal for picker prioritization
+
+### Instance Lifecycle
+
+1. **Spawn**: `terminal.spawn()` creates buffer → opens terminal with `termopen()` → registers via `instances.register_spawned()`
+2. **Track**: Instances stored in `state.state.claude_instances` with unique color index (1-8, wraps)
+3. **Focus**: `terminal.focus()` finds/switches to window containing buffer, enters insert mode
+4. **Cleanup**: `TermClose` autocmd triggers `instances.unregister()`, updates status bar
+
+### UI Components
+
+The plugin uses different UI strategies for its components:
+- **Editor**: Floating window (z=50), 60% width × 40% height, bottom-centered
+- **Status bar**: Native `vim.wo.winbar` applied to all non-floating windows, displays instance bubbles
+- **Picker**: Uses native `vim.ui.select`, integrates with telescope/fzf-lua if available
+
+### Multi-Tab Prompt Editor
+
+The editor supports multiple prompt tabs:
+- Tabs stored in `state.state.editor.tabs` as `{buf, name}` pairs
+- Names auto-generated as "prompt-N" (fills gaps in numbering, checks existing buffers)
+- Each tab preserves cursor position (mark 'p') and insert mode state (`vim.b[buf].prompt_was_insert`)
+- Tab deletion switches buffer before deleting to prevent window close
+
+### Keymaps System
+
+Uses a hybrid approach:
+1. **<Plug> mappings** - Global function references (e.g., `<Plug>(OrchestratorSend)`)
+2. **Buffer-local keymaps** - Applied when editor opens, configurable via `setup({keymaps = {...}})`
+3. **User commands** - `:PromptEditorToggle`, `:AgentsPick`, `:AgentsSpawn`, etc.
+
+Keymap config validation in `validate_config()` - values must be string or false (to disable).
+
+### Status Bar (Winbar) Rendering
+
+Uses native `vim.wo.winbar` with statusline format syntax (`%#Highlight#text`):
+- Applied to all non-floating, non-special windows via `WinEnter`/`BufEnter` autocmds
+- 8 color palettes with Active/Dim variants for body and ActiveCap/DimCap for bubble borders
+- Bubble effect with powerline semicircles (`` U+E0B6, `` U+E0B4)
+- Active instance: the one whose window matches `vim.api.nvim_get_current_win()`
+- Title display: reads `vim.b.term_title` (populated by Neovim from OSC 2 sequences)
+- Title updates debounced via `TermRequest` autocmd (50ms) to prevent flicker during streaming
+
+Key functions in `status_bar.lua`:
+- `build_winbar_string()` - constructs the statusline format string with highlight groups
+- `apply_to_all_windows()` - applies winbar to all applicable windows (uses pcall for safety)
+- `should_apply_winbar()` - filters out floating windows, quickfix, loclist, nofile buffers
+- `update()` - main entry point called when instances change or focus shifts
+
+## Key Patterns
+
+### Defensive Window/Buffer Checks
+
+Always validate before operations:
+```lua
+if state.state.editor.win and vim.api.nvim_win_is_valid(state.state.editor.win) then
+```
+
+### Window Lookup Optimization
+
+`instances.lua` uses `build_window_lookup()` to create buf→win mapping once rather than iterating windows per buffer (O(w) vs O(n*w)).
+
+### Job Validation
+
+Before sending to terminal, validate job is running:
+```lua
+local job_status = vim.fn.jobwait({ term.job_id }, 0)[1]
+if job_status ~= -1 then -- -1 means still running
+```
+
+### Scheduled Callbacks
+
+Use `vim.schedule()` in async contexts (TermClose, on_exit) to ensure Neovim state is consistent.
+
+## Testing Considerations
+
+- `teardown()` cleans all state for test isolation
+- `reload()` preserves Claude instances while refreshing code
+- Buffer names must be unique - `generate_tab_name()` checks both tabs array and `vim.fn.bufexists()`

--- a/lua/orchestrator/editor.lua
+++ b/lua/orchestrator/editor.lua
@@ -531,4 +531,16 @@ function M.current_tab_index()
 	return state.state.editor.current_tab_idx
 end
 
+--- Check if the current buffer is a prompt editor buffer
+--- @return boolean
+function M.is_current_buffer_prompt()
+	local current_buf = vim.api.nvim_get_current_buf()
+	for _, tab in ipairs(state.state.editor.tabs) do
+		if tab.buf == current_buf then
+			return true
+		end
+	end
+	return false
+end
+
 return M

--- a/lua/orchestrator/highlights.lua
+++ b/lua/orchestrator/highlights.lua
@@ -10,7 +10,6 @@ M.colors = {
 	white = "#DDDDDD", -- fg_primary from wine theme
 	black = "#131313", -- bg_primary from wine theme
 	yellow = "#fdd888", -- func from wine theme
-	winbar_bg = "#1a1a1a", -- slightly lighter than black for winbar background
 }
 
 -- Instance color palette (8 distinct colors for Claude instances)
@@ -46,22 +45,34 @@ end
 --- Setup all highlight groups
 --- Call this during plugin setup
 function M.setup()
-	-- Winbar base highlight (solid background spanning full width)
+	-- Override Neovim's default WinBar highlights for transparency
+	-- In Neovim 0.10+, WinBar is linked to StatusLine by default which may have a background
+	-- We explicitly set these to ensure transparent winbar background
+	vim.api.nvim_set_hl(0, "WinBar", {
+		fg = M.colors.white,
+		bg = "NONE",
+	})
+	vim.api.nvim_set_hl(0, "WinBarNC", {
+		fg = M.colors.white,
+		bg = "NONE",
+	})
+
+	-- Winbar base highlight (transparent background)
 	vim.api.nvim_set_hl(0, "OrchestratorWinbar", {
 		fg = M.colors.white,
-		bg = M.colors.winbar_bg,
+		bg = "NONE",
 	})
 
 	-- Winbar text (for labels and separators)
 	vim.api.nvim_set_hl(0, "OrchestratorWinbarText", {
 		fg = M.colors.white,
-		bg = M.colors.winbar_bg,
+		bg = "NONE",
 	})
 
 	-- Winbar separator between instances
 	vim.api.nvim_set_hl(0, "OrchestratorWinbarSep", {
 		fg = "#555555",
-		bg = M.colors.winbar_bg,
+		bg = "NONE",
 	})
 
 	-- Create highlight groups for each instance color

--- a/lua/orchestrator/highlights.lua
+++ b/lua/orchestrator/highlights.lua
@@ -42,6 +42,16 @@ local function dim_color(hex, factor)
 	return string.format("#%02X%02X%02X", r, g, b)
 end
 
+--- Validate and normalize color index to valid range (1-8)
+--- @param color_idx number|nil Raw color index
+--- @return number valid_idx Validated index (defaults to 1 if invalid)
+local function validate_color_idx(color_idx)
+	if type(color_idx) ~= "number" or color_idx < 1 or color_idx > 8 then
+		return 1
+	end
+	return math.floor(color_idx)
+end
+
 --- Setup all highlight groups
 --- Call this during plugin setup
 function M.setup()
@@ -60,18 +70,6 @@ function M.setup()
 	-- Winbar base highlight (transparent background)
 	vim.api.nvim_set_hl(0, "OrchestratorWinbar", {
 		fg = M.colors.white,
-		bg = "NONE",
-	})
-
-	-- Winbar text (for labels and separators)
-	vim.api.nvim_set_hl(0, "OrchestratorWinbarText", {
-		fg = M.colors.white,
-		bg = "NONE",
-	})
-
-	-- Winbar separator between instances
-	vim.api.nvim_set_hl(0, "OrchestratorWinbarSep", {
-		fg = "#555555",
 		bg = "NONE",
 	})
 
@@ -120,42 +118,43 @@ end
 --- @param color_idx number Color index (1-8)
 --- @return string highlight_group
 function M.get_instance_active_highlight(color_idx)
-	return "OrchestratorClaude" .. color_idx .. "Active"
+	return "OrchestratorClaude" .. validate_color_idx(color_idx) .. "Active"
 end
 
 --- Get highlight group name for inactive instance (dimmed background)
 --- @param color_idx number Color index (1-8)
 --- @return string highlight_group
 function M.get_instance_dim_highlight(color_idx)
-	return "OrchestratorClaude" .. color_idx .. "Dim"
+	return "OrchestratorClaude" .. validate_color_idx(color_idx) .. "Dim"
 end
 
 --- Get highlight group name for active bubble cap (colored fg, transparent bg)
 --- @param color_idx number Color index (1-8)
 --- @return string highlight_group
 function M.get_instance_active_cap_highlight(color_idx)
-	return "OrchestratorClaude" .. color_idx .. "ActiveCap"
+	return "OrchestratorClaude" .. validate_color_idx(color_idx) .. "ActiveCap"
 end
 
 --- Get highlight group name for inactive bubble cap (dimmed fg, transparent bg)
 --- @param color_idx number Color index (1-8)
 --- @return string highlight_group
 function M.get_instance_dim_cap_highlight(color_idx)
-	return "OrchestratorClaude" .. color_idx .. "DimCap"
+	return "OrchestratorClaude" .. validate_color_idx(color_idx) .. "DimCap"
 end
 
 --- Get highlight group name for colored text (no background)
 --- @param color_idx number Color index (1-8)
 --- @return string highlight_group
 function M.get_instance_highlight(color_idx)
-	return "OrchestratorClaude" .. color_idx
+	return "OrchestratorClaude" .. validate_color_idx(color_idx)
 end
 
 --- Get color name for display (e.g., in picker)
 --- @param color_idx number Color index (1-8)
 --- @return string color_name
 function M.get_color_name(color_idx)
-	local color = M.instance_colors[color_idx]
+	local idx = validate_color_idx(color_idx)
+	local color = M.instance_colors[idx]
 	return color and color.name or "Unknown"
 end
 

--- a/lua/orchestrator/highlights.lua
+++ b/lua/orchestrator/highlights.lua
@@ -88,11 +88,23 @@ function M.setup()
 			bold = true,
 		})
 
+		-- Active bubble cap: colored foreground on transparent (for powerline semicircles)
+		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "ActiveCap", {
+			fg = color.fg,
+			bg = "NONE",
+		})
+
 		-- Inactive instance: dark text on dimmed colored background
 		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "Dim", {
 			fg = M.colors.black,
 			bg = dimmed_fg,
 			bold = true,
+		})
+
+		-- Inactive bubble cap: dimmed foreground on transparent (for powerline semicircles)
+		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "DimCap", {
+			fg = dimmed_fg,
+			bg = "NONE",
 		})
 
 		-- Simple colored text variant (used in picker, etc.)
@@ -116,6 +128,20 @@ end
 --- @return string highlight_group
 function M.get_instance_dim_highlight(color_idx)
 	return "OrchestratorClaude" .. color_idx .. "Dim"
+end
+
+--- Get highlight group name for active bubble cap (colored fg, transparent bg)
+--- @param color_idx number Color index (1-8)
+--- @return string highlight_group
+function M.get_instance_active_cap_highlight(color_idx)
+	return "OrchestratorClaude" .. color_idx .. "ActiveCap"
+end
+
+--- Get highlight group name for inactive bubble cap (dimmed fg, transparent bg)
+--- @param color_idx number Color index (1-8)
+--- @return string highlight_group
+function M.get_instance_dim_cap_highlight(color_idx)
+	return "OrchestratorClaude" .. color_idx .. "DimCap"
 end
 
 --- Get highlight group name for colored text (no background)

--- a/lua/orchestrator/highlights.lua
+++ b/lua/orchestrator/highlights.lua
@@ -1,6 +1,6 @@
 -- Highlights Module
 -- Color palette and highlight group definitions
--- Styled to match user's lualine theme (transparent backgrounds)
+-- Styled for winbar with flat lualine-style backgrounds
 
 ---@class HighlightsModule
 local M = {}
@@ -10,6 +10,7 @@ M.colors = {
 	white = "#DDDDDD", -- fg_primary from wine theme
 	black = "#131313", -- bg_primary from wine theme
 	yellow = "#fdd888", -- func from wine theme
+	winbar_bg = "#1a1a1a", -- slightly lighter than black for winbar background
 }
 
 -- Instance color palette (8 distinct colors for Claude instances)
@@ -24,9 +25,6 @@ M.instance_colors = {
 	{ name = "Amber", fg = "#c28b12" }, -- keyword amber (syntax)
 	{ name = "Peach", fg = "#E19773" }, -- variable peach (syntax)
 }
-
--- Namespace for status bar extmarks
-M.namespace = nil
 
 -- Dim factor for inactive agents (0.55 = 55% brightness)
 local DIM_FACTOR = 0.55
@@ -48,108 +46,72 @@ end
 --- Setup all highlight groups
 --- Call this during plugin setup
 function M.setup()
-	-- Create namespace for status bar highlights
-	M.namespace = vim.api.nvim_create_namespace("OrchestratorStatusBar")
+	-- Winbar base highlight (solid background spanning full width)
+	vim.api.nvim_set_hl(0, "OrchestratorWinbar", {
+		fg = M.colors.white,
+		bg = M.colors.winbar_bg,
+	})
+
+	-- Winbar text (for labels and separators)
+	vim.api.nvim_set_hl(0, "OrchestratorWinbarText", {
+		fg = M.colors.white,
+		bg = M.colors.winbar_bg,
+	})
+
+	-- Winbar separator between instances
+	vim.api.nvim_set_hl(0, "OrchestratorWinbarSep", {
+		fg = "#555555",
+		bg = M.colors.winbar_bg,
+	})
 
 	-- Create highlight groups for each instance color
 	-- OrchestratorClaude1 through OrchestratorClaude8
 	for i, color in ipairs(M.instance_colors) do
-		-- Inactive state: colored text on transparent background
-		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i, {
-			fg = color.fg,
-			bg = "none", -- Transparent to match lualine
-			bold = true,
-		})
+		-- Dimmed variants for inactive agents
+		local dimmed_fg = dim_color(color.fg, DIM_FACTOR)
 
-		-- Active bubble body: dark text on colored background
+		-- Active instance: dark text on colored background (full brightness)
 		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "Active", {
 			fg = M.colors.black,
 			bg = color.fg,
 			bold = true,
 		})
 
-		-- Left chevron (): transitions into the bubble
-		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "ChevronLeft", {
-			fg = color.fg,
-			bg = "none",
-		})
-
-		-- Right chevron (): transitions out of the bubble
-		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "ChevronRight", {
-			fg = color.fg,
-			bg = "none",
-		})
-
-		-- Dimmed variants for inactive agents
-		local dimmed_fg = dim_color(color.fg, DIM_FACTOR)
-
-		-- Dimmed bubble body: dark text on dimmed colored background
+		-- Inactive instance: dark text on dimmed colored background
 		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "Dim", {
 			fg = M.colors.black,
 			bg = dimmed_fg,
 			bold = true,
 		})
 
-		-- Dimmed left cap
-		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "ChevronLeftDim", {
-			fg = dimmed_fg,
+		-- Simple colored text variant (used in picker, etc.)
+		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i, {
+			fg = color.fg,
 			bg = "none",
-		})
-
-		-- Dimmed right cap
-		vim.api.nvim_set_hl(0, "OrchestratorClaude" .. i .. "ChevronRightDim", {
-			fg = dimmed_fg,
-			bg = "none",
+			bold = true,
 		})
 	end
-
-	-- Base status bar highlight (for brackets and spacing)
-	vim.api.nvim_set_hl(0, "OrchestratorStatusBar", {
-		fg = M.colors.white,
-		bg = "none",
-	})
-
-	-- Status bar window background (fully transparent)
-	vim.api.nvim_set_hl(0, "OrchestratorStatusBarBg", {
-		bg = "none",
-	})
 end
 
---- Get highlight group name for inactive instance
---- @param color_idx number Color index (1-8)
---- @return string highlight_group
-function M.get_instance_highlight(color_idx)
-	return "OrchestratorClaude" .. color_idx
-end
-
---- Get highlight group name for active bubble content
+--- Get highlight group name for active instance (full brightness background)
 --- @param color_idx number Color index (1-8)
 --- @return string highlight_group
 function M.get_instance_active_highlight(color_idx)
 	return "OrchestratorClaude" .. color_idx .. "Active"
 end
 
---- Get highlight group name for chevron separators
---- @param color_idx number Color index (1-8)
---- @param side "left"|"right" Side of the bubble cap
---- @return string highlight_group
-function M.get_instance_chevron_highlight(color_idx, side)
-	return "OrchestratorClaude" .. color_idx .. "Chevron" .. (side == "left" and "Left" or "Right")
-end
-
---- Get highlight group name for dimmed bubble content (inactive agents)
+--- Get highlight group name for inactive instance (dimmed background)
 --- @param color_idx number Color index (1-8)
 --- @return string highlight_group
 function M.get_instance_dim_highlight(color_idx)
 	return "OrchestratorClaude" .. color_idx .. "Dim"
 end
 
---- Get highlight group name for dimmed chevron separators (inactive agents)
+--- Get highlight group name for colored text (no background)
 --- @param color_idx number Color index (1-8)
---- @param side "left"|"right" Side of the bubble cap
 --- @return string highlight_group
-function M.get_instance_chevron_dim_highlight(color_idx, side)
-	return "OrchestratorClaude" .. color_idx .. "Chevron" .. (side == "left" and "Left" or "Right") .. "Dim"
+function M.get_instance_highlight(color_idx)
+	return "OrchestratorClaude" .. color_idx
 end
 
 --- Get color name for display (e.g., in picker)

--- a/lua/orchestrator/init.lua
+++ b/lua/orchestrator/init.lua
@@ -340,47 +340,25 @@ local function setup_terminal_autocmds()
 		end,
 	})
 
-	-- Window resized: reposition status bar
-	vim.api.nvim_create_autocmd("VimResized", {
-		group = augroup,
-		callback = function()
-			status_bar.reposition()
-		end,
-	})
-
-	-- Focus changed: update status bar to show active instance indicator
+	-- Focus changed: update winbar and track active instance
 	-- WinEnter: fires when switching windows (split navigation)
 	-- BufEnter: fires when switching buffers in same window (<C-6>, :bnext, etc.)
-	-- Updates when entering/leaving Claude terminals or any floating window
-	vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
+	-- BufWinEnter: fires when a buffer is displayed in a window (new splits, etc.)
+	-- Also applies winbar to new windows as they're created
+	vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter", "BufWinEnter" }, {
 		group = augroup,
 		callback = function()
-			if instances.count() == 0 then
-				return
-			end
-
 			local current_buf = vim.api.nvim_get_current_buf()
 			local current_win = vim.api.nvim_get_current_win()
-			local prev_buf = vim.fn.bufnr("#")
-
-			-- Check if entering/leaving a Claude terminal
-			local current_is_claude = instances.get_by_buf(current_buf) ~= nil
-			local prev_is_claude = prev_buf > 0 and instances.get_by_buf(prev_buf) ~= nil
-
-			-- Check if entering a floating window (editor, picker, telescope, etc.)
-			-- Floating windows have a non-empty 'relative' config
-			local win_config = vim.api.nvim_win_get_config(current_win)
-			local is_floating = win_config.relative and win_config.relative ~= ""
 
 			-- Track last active Claude instance for picker prioritization
+			local current_is_claude = instances.get_by_buf(current_buf) ~= nil
 			if current_is_claude then
 				state.state.last_active_buf = current_buf
 			end
 
-			-- Update status bar when entering/leaving Claude terminals or any floating window
-			if current_is_claude or prev_is_claude or is_floating then
-				status_bar.update()
-			end
+			-- Apply winbar to this window (handles visibility and instance count internally)
+			status_bar.apply_to_window(current_win)
 		end,
 	})
 end
@@ -487,8 +465,8 @@ local function setup_user_commands()
 				tostring(inst.dangerous or false)
 			))
 		end
-		print("Status bar visible: " .. tostring(state.state.status_bar.visible))
-		print("Status bar win: " .. tostring(state.state.status_bar.win))
+		print("Winbar visible: " .. tostring(state.state.status_bar.visible))
+		print("Winbar string: " .. status_bar.get_winbar_string())
 	end, {
 		desc = "Debug orchestrator state",
 	})
@@ -646,11 +624,8 @@ local function cleanup_ui()
 		end
 	end
 
-	-- Hide and delete status bar
+	-- Hide winbar from all windows
 	status_bar.hide()
-	if state.state.status_bar.buf and vim.api.nvim_buf_is_valid(state.state.status_bar.buf) then
-		vim.api.nvim_buf_delete(state.state.status_bar.buf, { force = true })
-	end
 end
 
 --- Delete autocmds and user commands

--- a/lua/orchestrator/init.lua
+++ b/lua/orchestrator/init.lua
@@ -349,7 +349,6 @@ local function setup_terminal_autocmds()
 		group = augroup,
 		callback = function()
 			local current_buf = vim.api.nvim_get_current_buf()
-			local current_win = vim.api.nvim_get_current_win()
 
 			-- Track last active Claude instance for picker prioritization
 			local current_is_claude = instances.get_by_buf(current_buf) ~= nil
@@ -357,8 +356,9 @@ local function setup_terminal_autocmds()
 				state.state.last_active_buf = current_buf
 			end
 
-			-- Apply winbar to this window (handles visibility and instance count internally)
-			status_bar.apply_to_window(current_win)
+			-- Update all winbars to reflect correct active state
+			-- (must update all windows so previously active one dims)
+			status_bar.update()
 		end,
 	})
 end
@@ -630,6 +630,12 @@ end
 
 --- Delete autocmds and user commands
 local function cleanup_commands()
+	-- Stop pending debounce timer to prevent stale callbacks after reload
+	if title_update_timer then
+		pcall(vim.fn.timer_stop, title_update_timer)
+		title_update_timer = nil
+	end
+
 	pcall(vim.api.nvim_del_augroup_by_name, "Orchestrator")
 
 	for _, cmd in ipairs(user_commands) do

--- a/lua/orchestrator/init.lua
+++ b/lua/orchestrator/init.lua
@@ -26,6 +26,11 @@ local default_config = {
 			delete_tab = "<C-S-x>", -- Delete current tab
 		},
 	},
+	-- Dangerous mode configuration (--dangerously-skip-permissions)
+	dangerous_mode = {
+		enabled = true, -- Set to false to completely disable dangerous mode
+		require_confirmation = false, -- Prompt user before spawning in dangerous mode
+	},
 }
 
 --- Active configuration (merged with user opts)
@@ -135,6 +140,30 @@ end
 --- @param opts table|nil Options { dangerous = boolean }
 --- @return table|nil instance The spawned instance
 function M.spawn(spawn_type, opts)
+	opts = opts or {}
+
+	-- Check dangerous mode configuration
+	if opts.dangerous then
+		if not config.dangerous_mode.enabled then
+			vim.notify(
+				"Dangerous mode is disabled. Enable via setup({ dangerous_mode = { enabled = true } })",
+				vim.log.levels.ERROR
+			)
+			return nil
+		end
+
+		if config.dangerous_mode.require_confirmation then
+			local confirmed = vim.fn.confirm(
+				"Spawn Claude with --dangerously-skip-permissions?\n" .. "This bypasses all permission checks.",
+				"&Yes\n&No",
+				2 -- default to No
+			)
+			if confirmed ~= 1 then
+				return nil
+			end
+		end
+	end
+
 	return terminal.spawn(spawn_type or "fresh", opts)
 end
 
@@ -448,13 +477,14 @@ local function setup_user_commands()
 		print("Current cwd: " .. vim.fn.getcwd())
 		for i, inst in ipairs(all) do
 			print(string.format(
-				"  [%d] buf=%d, job_id=%d, color=%d, cwd=%s, type=%s",
+				"  [%d] buf=%d, job_id=%d, color=%d, cwd=%s, type=%s, dangerous=%s",
 				i,
 				inst.buf,
 				inst.job_id,
 				inst.color_idx,
 				inst.cwd,
-				inst.spawn_type
+				inst.spawn_type,
+				tostring(inst.dangerous or false)
 			))
 		end
 		print("Status bar visible: " .. tostring(state.state.status_bar.visible))

--- a/lua/orchestrator/init.lua
+++ b/lua/orchestrator/init.lua
@@ -132,9 +132,10 @@ end
 
 --- Spawn a new Claude terminal
 --- @param spawn_type string|nil "fresh" (default), "resume", or "continue"
+--- @param opts table|nil Options { dangerous = boolean }
 --- @return table|nil instance The spawned instance
-function M.spawn(spawn_type)
-	return terminal.spawn(spawn_type or "fresh")
+function M.spawn(spawn_type, opts)
+	return terminal.spawn(spawn_type or "fresh", opts)
 end
 
 --- Show unified picker to spawn or select Claude terminal
@@ -395,10 +396,12 @@ local function setup_user_commands()
 
 	vim.api.nvim_create_user_command("AgentsSpawn", function(opts)
 		local spawn_type = opts.args ~= "" and opts.args or "fresh"
-		M.spawn(spawn_type)
+		local dangerous = opts.bang
+		M.spawn(spawn_type, { dangerous = dangerous })
 	end, {
-		desc = "Spawn new Claude terminal",
+		desc = "Spawn new Claude terminal (use ! for dangerous mode)",
 		nargs = "?",
+		bang = true,
 		complete = function()
 			return { "fresh", "resume", "continue" }
 		end,
@@ -494,6 +497,17 @@ local function setup_plug_mappings()
 	vim.keymap.set("n", "<Plug>(OrchestratorSpawnContinue)", function()
 		M.spawn("continue")
 	end, { desc = "Spawn Claude terminal (continue)" })
+
+	-- Dangerous mode variants (--dangerously-skip-permissions)
+	vim.keymap.set("n", "<Plug>(OrchestratorSpawnDangerous)", function()
+		M.spawn("fresh", { dangerous = true })
+	end, { desc = "Spawn new Claude terminal (dangerous mode)" })
+	vim.keymap.set("n", "<Plug>(OrchestratorSpawnResumeDangerous)", function()
+		M.spawn("resume", { dangerous = true })
+	end, { desc = "Spawn Claude terminal (resume, dangerous mode)" })
+	vim.keymap.set("n", "<Plug>(OrchestratorSpawnContinueDangerous)", function()
+		M.spawn("continue", { dangerous = true })
+	end, { desc = "Spawn Claude terminal (continue, dangerous mode)" })
 end
 
 -- ============================================================

--- a/lua/orchestrator/init.lua
+++ b/lua/orchestrator/init.lua
@@ -44,6 +44,10 @@ local terminal = require("orchestrator.terminal")
 -- Create autocmd group
 local augroup = vim.api.nvim_create_augroup("Orchestrator", { clear = true })
 
+-- Debounce timer for terminal title updates
+local title_update_timer = nil
+local TITLE_DEBOUNCE_MS = 50
+
 -- ============================================================
 -- PUBLIC API: Editor Functions
 -- ============================================================
@@ -276,6 +280,32 @@ local function setup_terminal_autocmds()
 				if instances.get_by_buf(args.buf) then
 					instances.unregister(args.buf)
 				end
+			end)
+		end,
+	})
+
+	-- Terminal title changed: update status bar to show session name
+	-- TermRequest fires when terminal sends OSC/DCS escape sequences
+	-- Neovim updates vim.b.term_title from OSC 2 before this fires
+	-- Debounced to prevent flicker during rapid title updates (e.g., Claude streaming)
+	vim.api.nvim_create_autocmd("TermRequest", {
+		group = augroup,
+		callback = function(args)
+			-- Only process if it's a tracked Claude terminal
+			if not instances.get_by_buf(args.buf) then
+				return
+			end
+
+			-- Debounce: cancel pending update and schedule new one
+			if title_update_timer then
+				vim.fn.timer_stop(title_update_timer)
+			end
+
+			title_update_timer = vim.fn.timer_start(TITLE_DEBOUNCE_MS, function()
+				vim.schedule(function()
+					status_bar.update()
+					title_update_timer = nil
+				end)
 			end)
 		end,
 	})

--- a/lua/orchestrator/init.lua
+++ b/lua/orchestrator/init.lua
@@ -201,7 +201,14 @@ end
 
 --- Send prompt to Claude Code terminal
 --- Shows picker if multiple instances or spawn options
+--- Only works when called from inside the prompt editor
 function M.send_to_terminal()
+	-- Guard: Only allow sending from inside the prompt editor
+	if not editor.is_current_buffer_prompt() then
+		vim.notify("Send prompt only works inside the Prompt Editor", vim.log.levels.WARN)
+		return
+	end
+
 	local content = editor.get_content()
 
 	if not content then

--- a/lua/orchestrator/instances.lua
+++ b/lua/orchestrator/instances.lua
@@ -41,7 +41,7 @@ local MAX_INSTANCES = 8
 --- @param job_id number Terminal job ID
 --- @param cwd string Working directory at spawn time
 --- @param spawn_type string "fresh" | "resume" | "continue"
---- @param dangerous boolean|nil Whether instance was spawned with --dangerously-skip-permissions
+--- @param dangerous boolean|nil Whether instance was spawned with --dangerously-skip-permissions (nil treated as false)
 --- @return table instance The registered instance
 function M.register_spawned(buf, job_id, cwd, spawn_type, dangerous)
 	-- Check if already registered (prevent duplicates)

--- a/lua/orchestrator/instances.lua
+++ b/lua/orchestrator/instances.lua
@@ -41,8 +41,9 @@ local MAX_INSTANCES = 8
 --- @param job_id number Terminal job ID
 --- @param cwd string Working directory at spawn time
 --- @param spawn_type string "fresh" | "resume" | "continue"
+--- @param dangerous boolean|nil Whether instance was spawned with --dangerously-skip-permissions
 --- @return table instance The registered instance
-function M.register_spawned(buf, job_id, cwd, spawn_type)
+function M.register_spawned(buf, job_id, cwd, spawn_type, dangerous)
 	-- Check if already registered (prevent duplicates)
 	for _, inst in ipairs(state.state.claude_instances) do
 		if inst.buf == buf then
@@ -67,6 +68,7 @@ function M.register_spawned(buf, job_id, cwd, spawn_type)
 		cwd = cwd,
 		spawn_type = spawn_type,
 		spawned_at = os.time(),
+		dangerous = dangerous or false,
 	}
 
 	table.insert(state.state.claude_instances, instance)
@@ -133,6 +135,7 @@ function M.get_all()
 			cwd = inst.cwd,
 			spawn_type = inst.spawn_type,
 			spawned_at = inst.spawned_at,
+			dangerous = inst.dangerous,
 			number = i,
 			win = buf_to_win[inst.buf],
 		})
@@ -159,6 +162,7 @@ function M.get_for_current_project()
 				cwd = inst.cwd,
 				spawn_type = inst.spawn_type,
 				spawned_at = inst.spawned_at,
+				dangerous = inst.dangerous,
 				number = number,
 				win = buf_to_win[inst.buf],
 			})

--- a/lua/orchestrator/picker.lua
+++ b/lua/orchestrator/picker.lua
@@ -79,12 +79,14 @@ function M.select(callback)
 		elseif inst.spawn_type == "continue" then
 			spawn_label = " [continued]"
 		end
+		local danger_prefix = inst.dangerous and "⚠ " or ""
 
 		table.insert(items, {
 			type = "existing",
 			instance = inst,
 			display = string.format(
-				"[%d] Claude (%s)%s - %s",
+				"%s[%d] Claude (%s)%s - %s",
+				danger_prefix,
 				inst.number,
 				highlights.get_color_name(inst.color_idx),
 				spawn_label,
@@ -151,10 +153,12 @@ function M.select_existing(callback)
 	local items = {}
 	for _, inst in ipairs(project_instances) do
 		local time_ago = format_time_ago(inst.spawned_at)
+		local danger_prefix = inst.dangerous and "⚠ " or ""
 		table.insert(items, {
 			instance = inst,
 			display = string.format(
-				"[%d] Claude (%s) - %s",
+				"%s[%d] Claude (%s) - %s",
+				danger_prefix,
 				inst.number,
 				highlights.get_color_name(inst.color_idx),
 				time_ago

--- a/lua/orchestrator/state.lua
+++ b/lua/orchestrator/state.lua
@@ -15,11 +15,9 @@ M.state = {
 		current_tab_idx = 1, -- Index into tabs array (1-indexed)
 	},
 
-	-- Status bar state
+	-- Status bar state (winbar-based, no floating window)
 	status_bar = {
-		win = nil, -- Window ID of status bar
-		buf = nil, -- Buffer ID of status bar buffer
-		visible = true, -- Whether bar should be shown when instances exist
+		visible = true, -- Whether winbar should be shown when instances exist
 	},
 
 	-- Claude instance tracking (spawn-controlled)
@@ -46,8 +44,6 @@ function M.reset()
 	M.state.editor.win = nil
 	M.state.editor.tabs = {}
 	M.state.editor.current_tab_idx = 1
-	M.state.status_bar.win = nil
-	M.state.status_bar.buf = nil
 	M.state.status_bar.visible = true
 	M.state.claude_instances = {}
 	M.state.next_color_idx = 1

--- a/lua/orchestrator/status_bar.lua
+++ b/lua/orchestrator/status_bar.lua
@@ -32,6 +32,9 @@ local config = {
 local ACTIVE_PADDING = 2 -- spaces on each side for active bubble
 local INACTIVE_PADDING = 1 -- spaces on each side for inactive bubbles
 
+-- Dangerous mode indicator (warning sign U+26A0)
+local DANGER_INDICATOR = "⚠ "
+
 -- Shell names to filter out (before Claude sets actual title)
 local SHELL_NAMES = { "zsh", "bash", "fish", "sh", "dash", "ksh", "tcsh", "csh" }
 
@@ -163,8 +166,11 @@ local function calculate_content_width(all_instances, title_cache)
 		local is_active = is_instance_active(inst, in_claude, current_win)
 		local padding_size = is_active and ACTIVE_PADDING or INACTIVE_PADDING
 
-		-- Calculate bubble content width: padding + number + (separator + title)? + padding
+		-- Calculate bubble content width: padding + (danger?)+ number + (separator + title)? + padding
 		local content_width = padding_size -- left padding
+		if inst.dangerous then
+			content_width = content_width + vim.fn.strdisplaywidth(DANGER_INDICATOR)
+		end
 		content_width = content_width + vim.fn.strdisplaywidth(tostring(inst.number))
 
 		local title = title_cache[inst.buf]
@@ -290,17 +296,18 @@ local function render(buf)
 		local left_cap = config.bubble_left
 		local padding = string.rep(" ", is_active and ACTIVE_PADDING or INACTIVE_PADDING)
 
-		-- Build content: number + (separator + title)?
+		-- Build content: (danger?) + number + (separator + title)?
+		local danger_prefix = inst.dangerous and DANGER_INDICATOR or ""
 		local number_str = tostring(inst.number)
 		local title = title_cache[inst.buf]
 		local content
 
 		if title then
-			content = padding .. number_str .. config.title.separator .. title .. padding
+			content = padding .. danger_prefix .. number_str .. config.title.separator .. title .. padding
 		elseif config.title.fallback then
-			content = padding .. number_str .. config.title.separator .. config.title.fallback .. padding
+			content = padding .. danger_prefix .. number_str .. config.title.separator .. config.title.fallback .. padding
 		else
-			content = padding .. number_str .. padding
+			content = padding .. danger_prefix .. number_str .. padding
 		end
 
 		local right_cap = config.bubble_right

--- a/lua/orchestrator/status_bar.lua
+++ b/lua/orchestrator/status_bar.lua
@@ -36,31 +36,12 @@ local INSTANCE_PADDING = "  " -- Two spaces on each side
 -- Shell names to filter out (before Claude sets actual title)
 local SHELL_NAMES = { "zsh", "bash", "fish", "sh", "dash", "ksh", "tcsh", "csh" }
 
---- Check if the current window is a Claude terminal window
---- @return boolean is_claude_win True if current window is a Claude terminal
-local function is_in_claude_terminal()
-	local current_win = vim.api.nvim_get_current_win()
-	if not vim.api.nvim_win_is_valid(current_win) then
-		return false
-	end
-
-	for _, inst in ipairs(instances.get_all()) do
-		if inst.win and vim.api.nvim_win_is_valid(inst.win) and inst.win == current_win then
-			return true
-		end
-	end
-
-	return false
-end
-
---- Check if a specific instance is currently active
+--- Check if a specific instance is currently active (displayed in current window)
 --- @param inst table Instance object with win field
---- @param in_claude boolean Whether currently in a Claude terminal
 --- @param current_win number Current window ID
---- @return boolean is_active True if this instance is active
-local function is_instance_active(inst, in_claude, current_win)
-	return in_claude
-		and inst.win
+--- @return boolean is_active True if this instance is the active one
+local function is_instance_active(inst, current_win)
+	return inst.win
 		and vim.api.nvim_win_is_valid(inst.win)
 		and inst.win == current_win
 end
@@ -136,14 +117,11 @@ local function should_apply_winbar(win)
 		return false
 	end
 
-	-- Skip special buffer types
+	-- Skip special buffer types (quickfix, loclist, nofile)
+	-- Terminal buffers (buftype="terminal") are allowed so Claude instances get winbar
 	local buftype = vim.bo[buf].buftype
 	if buftype == "quickfix" or buftype == "loclist" or buftype == "nofile" then
-		-- Allow nofile only if it's our prompt editor
-		local bufname = vim.api.nvim_buf_get_name(buf)
-		if not bufname:match("^orchestrator://") then
-			return false
-		end
+		return false
 	end
 
 	return true
@@ -165,17 +143,16 @@ local function build_winbar_string()
 		title_cache[inst.buf] = get_instance_title(inst.buf)
 	end
 
-	-- Detect active instance context
+	-- Get current window for active state detection
 	local current_win = vim.api.nvim_get_current_win()
-	local in_claude_terminal = is_in_claude_terminal()
 
 	-- Build the winbar string with statusline format syntax
 	-- Start with background and center alignment
 	local parts = { "%#OrchestratorWinbar#%=" }
 
 	for i, inst in ipairs(all_instances) do
-		-- Determine if this instance is active
-		local is_active = is_instance_active(inst, in_claude_terminal, current_win)
+		-- Determine if this instance is active (its window is focused)
+		local is_active = is_instance_active(inst, current_win)
 
 		-- Select highlight groups based on active state
 		local body_hl = is_active
@@ -222,7 +199,10 @@ end
 local function apply_to_all_windows(winbar_str)
 	for _, win in ipairs(vim.api.nvim_list_wins()) do
 		if should_apply_winbar(win) then
-			vim.wo[win].winbar = winbar_str
+			-- Use pcall to handle race condition where window closes between check and assignment
+			pcall(function()
+				vim.wo[win].winbar = winbar_str
+			end)
 		end
 	end
 end
@@ -268,26 +248,6 @@ function M.toggle()
 		M.show()
 	else
 		M.hide()
-	end
-end
-
---- Apply winbar to a specific window (called from autocmd)
---- @param win number Window ID to apply winbar to
-function M.apply_to_window(win)
-	if not state.state.status_bar.visible then
-		return
-	end
-
-	if instances.count() == 0 then
-		if vim.api.nvim_win_is_valid(win) then
-			vim.wo[win].winbar = ""
-		end
-		return
-	end
-
-	if should_apply_winbar(win) then
-		local winbar_str = build_winbar_string()
-		vim.wo[win].winbar = winbar_str
 	end
 end
 

--- a/lua/orchestrator/status_bar.lua
+++ b/lua/orchestrator/status_bar.lua
@@ -22,6 +22,11 @@ local config = {
 	instance_separator = "  ", -- Two spaces between instance segments
 }
 
+-- Bubble cap symbols (powerline semicircles)
+local BUBBLE_LEFT = "" -- U+E0B6 (left semicircle)
+local BUBBLE_RIGHT = "" -- U+E0B4 (right semicircle)
+
+
 -- Dangerous mode indicator (warning sign U+26A0)
 local DANGER_INDICATOR = "⚠ "
 
@@ -172,10 +177,13 @@ local function build_winbar_string()
 		-- Determine if this instance is active
 		local is_active = is_instance_active(inst, in_claude_terminal, current_win)
 
-		-- Select highlight group based on active state
-		local hl_group = is_active
+		-- Select highlight groups based on active state
+		local body_hl = is_active
 				and highlights.get_instance_active_highlight(inst.color_idx)
 			or highlights.get_instance_dim_highlight(inst.color_idx)
+		local cap_hl = is_active
+				and highlights.get_instance_active_cap_highlight(inst.color_idx)
+			or highlights.get_instance_dim_cap_highlight(inst.color_idx)
 
 		-- Build content: padding + (danger?) + number + (separator + title)? + padding
 		local danger_prefix = inst.dangerous and DANGER_INDICATOR or ""
@@ -191,8 +199,11 @@ local function build_winbar_string()
 			content = INSTANCE_PADDING .. danger_prefix .. number_str .. INSTANCE_PADDING
 		end
 
-		-- Add highlighted segment: %#HighlightGroup#content
-		table.insert(parts, string.format("%%#%s#%s", hl_group, content))
+		-- Add bubble: left_cap + content + right_cap
+		-- Caps use cap_hl (colored fg, transparent bg), body uses body_hl (dark fg, colored bg)
+		table.insert(parts, string.format("%%#%s#%s", cap_hl, BUBBLE_LEFT))
+		table.insert(parts, string.format("%%#%s#%s", body_hl, content))
+		table.insert(parts, string.format("%%#%s#%s", cap_hl, BUBBLE_RIGHT))
 
 		-- Add separator between instances (with winbar background)
 		if i < #all_instances then

--- a/lua/orchestrator/status_bar.lua
+++ b/lua/orchestrator/status_bar.lua
@@ -1,6 +1,6 @@
 -- Status Bar Module
--- Floating status bar UI for displaying Claude instances
--- Positioned above lualine, styled to match its aesthetic
+-- Winbar-based status bar for displaying Claude instances
+-- Uses vim.wo.winbar with statusline format strings for lualine-style rendering
 
 local state = require("orchestrator.state")
 local highlights = require("orchestrator.highlights")
@@ -11,14 +11,6 @@ local M = {}
 
 -- Configuration constants
 local config = {
-	zindex = 45, -- Below editor (50), above normal content
-	lualine_offset = 3, -- Lines from bottom (cmdline=-1, statusline=-2, bar=-3)
-	min_width = 10, -- Minimum window width
-	padding = 4, -- Horizontal padding around content
-	max_width_ratio = 0.8, -- Maximum 80% of screen width
-	-- Bubble effect separators (powerline rounded symbols)
-	bubble_left = "", -- U+E0B6 (left semicircle)
-	bubble_right = "", -- U+E0B4 (right semicircle)
 	-- Title display settings
 	title = {
 		max_length = 32, -- Maximum characters before truncation
@@ -26,14 +18,15 @@ local config = {
 		separator = " │ ", -- Between number and title (U+2502 thin vertical bar)
 		fallback = nil, -- Show when no title available (nil = number only)
 	},
+	-- Separators between instances
+	instance_separator = "  ", -- Two spaces between instance segments
 }
-
--- Padding constants for bubble content
-local ACTIVE_PADDING = 2 -- spaces on each side for active bubble
-local INACTIVE_PADDING = 1 -- spaces on each side for inactive bubbles
 
 -- Dangerous mode indicator (warning sign U+26A0)
 local DANGER_INDICATOR = "⚠ "
+
+-- Padding around instance content
+local INSTANCE_PADDING = "  " -- Two spaces on each side
 
 -- Shell names to filter out (before Claude sets actual title)
 local SHELL_NAMES = { "zsh", "bash", "fish", "sh", "dash", "ksh", "tcsh", "csh" }
@@ -65,35 +58,6 @@ local function is_instance_active(inst, in_claude, current_win)
 		and inst.win
 		and vim.api.nvim_win_is_valid(inst.win)
 		and inst.win == current_win
-end
-
---- Check if any Claude instance is currently active
---- Mirrors the logic in render() to determine active state
---- @return boolean has_active True if an instance is active
-local function has_active_instance()
-	local all_instances = instances.get_all()
-	if #all_instances == 0 then
-		return false
-	end
-
-	local current_win = vim.api.nvim_get_current_win()
-	if not vim.api.nvim_win_is_valid(current_win) then
-		return false
-	end
-
-	-- Only show active indicator when inside a Claude terminal
-	if not is_in_claude_terminal() then
-		return false
-	end
-
-	-- Check if current window matches any Claude instance
-	for _, inst in ipairs(all_instances) do
-		if inst.win and vim.api.nvim_win_is_valid(inst.win) and inst.win == current_win then
-			return true
-		end
-	end
-
-	return false
 end
 
 --- Get and truncate the session title for an instance
@@ -146,246 +110,116 @@ local function get_instance_title(buf)
 	return title
 end
 
---- Calculate the content width based on number of instances and their titles
---- Iterates through instances to sum variable widths (titles vary in length)
---- @param all_instances table Array of instance objects
---- @param title_cache table Map of buf -> title (cached lookups)
---- @return number width Content width in display columns
-local function calculate_content_width(all_instances, title_cache)
-	local count = #all_instances
-	if count == 0 then
-		return 0
+--- Check if a window should have the winbar applied
+--- Excludes floating windows, special buffers, etc.
+--- @param win number Window ID
+--- @return boolean should_apply True if winbar should be applied
+local function should_apply_winbar(win)
+	if not vim.api.nvim_win_is_valid(win) then
+		return false
 	end
 
-	local current_win = vim.api.nvim_get_current_win()
-	local in_claude = is_in_claude_terminal()
-	local total_width = 0
+	-- Skip floating windows
+	local win_config = vim.api.nvim_win_get_config(win)
+	if win_config.relative ~= "" then
+		return false
+	end
 
-	for i, inst in ipairs(all_instances) do
-		-- Determine if this instance is active (for padding calculation)
-		local is_active = is_instance_active(inst, in_claude, current_win)
-		local padding_size = is_active and ACTIVE_PADDING or INACTIVE_PADDING
+	-- Get the buffer in this window
+	local buf = vim.api.nvim_win_get_buf(win)
+	if not vim.api.nvim_buf_is_valid(buf) then
+		return false
+	end
 
-		-- Calculate bubble content width: padding + (danger?)+ number + (separator + title)? + padding
-		local content_width = padding_size -- left padding
-		if inst.dangerous then
-			content_width = content_width + vim.fn.strdisplaywidth(DANGER_INDICATOR)
-		end
-		content_width = content_width + vim.fn.strdisplaywidth(tostring(inst.number))
-
-		local title = title_cache[inst.buf]
-		if title then
-			content_width = content_width + vim.fn.strdisplaywidth(config.title.separator)
-			content_width = content_width + vim.fn.strdisplaywidth(title)
-		elseif config.title.fallback then
-			content_width = content_width + vim.fn.strdisplaywidth(config.title.separator)
-			content_width = content_width + vim.fn.strdisplaywidth(config.title.fallback)
-		end
-
-		content_width = content_width + padding_size -- right padding
-
-		-- Add bubble caps
-		content_width = content_width + vim.fn.strdisplaywidth(config.bubble_left)
-		content_width = content_width + vim.fn.strdisplaywidth(config.bubble_right)
-
-		total_width = total_width + content_width
-
-		-- Add space between bubbles
-		if i < count then
-			total_width = total_width + 1
+	-- Skip special buffer types
+	local buftype = vim.bo[buf].buftype
+	if buftype == "quickfix" or buftype == "loclist" or buftype == "nofile" then
+		-- Allow nofile only if it's our prompt editor
+		local bufname = vim.api.nvim_buf_get_name(buf)
+		if not bufname:match("^orchestrator://") then
+			return false
 		end
 	end
 
-	return total_width
+	return true
 end
 
---- Get window position for status bar
---- Positioned just above lualine
---- @param all_instances? table Array of instance objects (optional, fetched if nil)
---- @param title_cache? table Map of buf -> title (optional, built if nil)
---- @return table win_opts Window configuration
-local function get_position(all_instances, title_cache)
-	-- Fallback: fetch instances and build cache if not provided
-	if not all_instances then
-		all_instances = instances.get_all()
-	end
-	if not title_cache then
-		title_cache = {}
-		for _, inst in ipairs(all_instances) do
-			title_cache[inst.buf] = get_instance_title(inst.buf)
-		end
-	end
-	local content_width = calculate_content_width(all_instances, title_cache)
-	local max_width = math.floor(vim.o.columns * config.max_width_ratio)
-	local width = math.max(config.min_width, math.min(content_width + config.padding, max_width))
-
-	return {
-		relative = "editor",
-		width = width,
-		height = 1,
-		row = vim.o.lines - config.lualine_offset,
-		col = math.floor((vim.o.columns - width) / 2),
-		style = "minimal",
-		border = "none",
-		focusable = false,
-		zindex = config.zindex,
-	}
-end
-
---- Create or get the status bar buffer
---- @return number buf Buffer ID
-local function get_or_create_buffer()
-	if state.state.status_bar.buf and vim.api.nvim_buf_is_valid(state.state.status_bar.buf) then
-		return state.state.status_bar.buf
-	end
-
-	local buf = vim.api.nvim_create_buf(false, true) -- unlisted, scratch
-
-	vim.bo[buf].buftype = "nofile"
-	vim.bo[buf].bufhidden = "wipe"
-	vim.bo[buf].swapfile = false
-	vim.bo[buf].modifiable = true
-
-	vim.api.nvim_buf_set_name(buf, "orchestrator-status-bar")
-
-	state.state.status_bar.buf = buf
-	return buf
-end
-
---- Render status bar content with colored instance indicators
---- Active instance displayed as bubble with chevron separators
---- Inactive instances displayed with parentheses
---- @param buf number Status bar buffer
-local function render(buf)
+--- Build the winbar string using statusline format syntax
+--- Format: %#Highlight#text for colored segments
+--- @return string winbar_str The formatted winbar string
+local function build_winbar_string()
 	local all_instances = instances.get_all()
 
 	if #all_instances == 0 then
-		vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "" })
-		return
+		return ""
 	end
 
-	-- Cache titles once for both width calculation and rendering
+	-- Cache titles once for rendering
 	local title_cache = {}
 	for _, inst in ipairs(all_instances) do
 		title_cache[inst.buf] = get_instance_title(inst.buf)
 	end
 
-	-- Detect active instance (the one in the current window)
+	-- Detect active instance context
 	local current_win = vim.api.nvim_get_current_win()
-
-	-- Validate current window before proceeding
-	if not vim.api.nvim_win_is_valid(current_win) then
-		return
-	end
-
-	-- Check if we're currently in a Claude terminal window
 	local in_claude_terminal = is_in_claude_terminal()
 
-	local win_opts = get_position(all_instances, title_cache)
-
-	-- Build parts and track highlight regions
-	local parts = {}
-	local highlight_regions = {} -- {start_byte, end_byte, hl_group}
-	local byte_offset = 0 -- Track byte position for extmarks
+	-- Build the winbar string with statusline format syntax
+	-- Start with background and center alignment
+	local parts = { "%#OrchestratorWinbar#%=" }
 
 	for i, inst in ipairs(all_instances) do
-		-- Only mark as active when inside a Claude terminal that matches this instance
+		-- Determine if this instance is active
 		local is_active = is_instance_active(inst, in_claude_terminal, current_win)
 
-		-- Bubble format: active gets wider padding for emphasis
-		local left_cap = config.bubble_left
-		local padding = string.rep(" ", is_active and ACTIVE_PADDING or INACTIVE_PADDING)
+		-- Select highlight group based on active state
+		local hl_group = is_active
+				and highlights.get_instance_active_highlight(inst.color_idx)
+			or highlights.get_instance_dim_highlight(inst.color_idx)
 
-		-- Build content: (danger?) + number + (separator + title)?
+		-- Build content: padding + (danger?) + number + (separator + title)? + padding
 		local danger_prefix = inst.dangerous and DANGER_INDICATOR or ""
 		local number_str = tostring(inst.number)
 		local title = title_cache[inst.buf]
 		local content
 
 		if title then
-			content = padding .. danger_prefix .. number_str .. config.title.separator .. title .. padding
+			content = INSTANCE_PADDING .. danger_prefix .. number_str .. config.title.separator .. title .. INSTANCE_PADDING
 		elseif config.title.fallback then
-			content = padding .. danger_prefix .. number_str .. config.title.separator .. config.title.fallback .. padding
+			content = INSTANCE_PADDING .. danger_prefix .. number_str .. config.title.separator .. config.title.fallback .. INSTANCE_PADDING
 		else
-			content = padding .. danger_prefix .. number_str .. padding
+			content = INSTANCE_PADDING .. danger_prefix .. number_str .. INSTANCE_PADDING
 		end
 
-		local right_cap = config.bubble_right
+		-- Add highlighted segment: %#HighlightGroup#content
+		table.insert(parts, string.format("%%#%s#%s", hl_group, content))
 
-		-- Add parts
-		table.insert(parts, left_cap)
-		table.insert(parts, content)
-		table.insert(parts, right_cap)
-
-		-- Determine highlight groups based on active state
-		-- Active: full brightness, Inactive: dimmed
-		local left_cap_hl, content_hl, right_cap_hl
-		if is_active then
-			left_cap_hl = highlights.get_instance_chevron_highlight(inst.color_idx, "left")
-			content_hl = highlights.get_instance_active_highlight(inst.color_idx)
-			right_cap_hl = highlights.get_instance_chevron_highlight(inst.color_idx, "right")
-		else
-			left_cap_hl = highlights.get_instance_chevron_dim_highlight(inst.color_idx, "left")
-			content_hl = highlights.get_instance_dim_highlight(inst.color_idx)
-			right_cap_hl = highlights.get_instance_chevron_dim_highlight(inst.color_idx, "right")
-		end
-
-		-- Track highlight regions for left bubble cap
-		table.insert(highlight_regions, {
-			start_byte = byte_offset,
-			end_byte = byte_offset + #left_cap,
-			hl_group = left_cap_hl,
-		})
-		byte_offset = byte_offset + #left_cap
-
-		-- Track highlight regions for content
-		table.insert(highlight_regions, {
-			start_byte = byte_offset,
-			end_byte = byte_offset + #content,
-			hl_group = content_hl,
-		})
-		byte_offset = byte_offset + #content
-
-		-- Track highlight regions for right bubble cap
-		table.insert(highlight_regions, {
-			start_byte = byte_offset,
-			end_byte = byte_offset + #right_cap,
-			hl_group = right_cap_hl,
-		})
-		byte_offset = byte_offset + #right_cap
-
-		-- Add space between instances
+		-- Add separator between instances (with winbar background)
 		if i < #all_instances then
-			table.insert(parts, " ")
-			byte_offset = byte_offset + 1
+			table.insert(parts, string.format("%%#OrchestratorWinbar#%s", config.instance_separator))
 		end
 	end
 
-	local line = table.concat(parts)
+	-- End with background fill and right alignment marker
+	table.insert(parts, "%#OrchestratorWinbar#%=")
 
-	-- Center the content with padding
-	local display_width = vim.fn.strdisplaywidth(line)
-	local padding = math.max(0, math.floor((win_opts.width - display_width) / 2))
-	local padded_line = string.rep(" ", padding) .. line
+	return table.concat(parts)
+end
 
-	vim.bo[buf].modifiable = true
-	vim.api.nvim_buf_set_lines(buf, 0, -1, false, { padded_line })
-	vim.bo[buf].modifiable = false
-
-	-- Apply highlights using extmarks
-	vim.api.nvim_buf_clear_namespace(buf, highlights.namespace, 0, -1)
-
-	for _, region in ipairs(highlight_regions) do
-		vim.api.nvim_buf_set_extmark(buf, highlights.namespace, 0, padding + region.start_byte, {
-			end_col = padding + region.end_byte,
-			hl_group = region.hl_group,
-		})
+--- Apply winbar to all applicable windows
+--- @param winbar_str string The winbar string to apply (empty string to clear)
+local function apply_to_all_windows(winbar_str)
+	for _, win in ipairs(vim.api.nvim_list_wins()) do
+		if should_apply_winbar(win) then
+			vim.wo[win].winbar = winbar_str
+		end
 	end
 end
 
---- Show the status bar floating window
+--- Show the winbar on all windows
 function M.show()
 	if instances.count() == 0 then
+		M.hide()
 		return
 	end
 
@@ -393,36 +227,16 @@ function M.show()
 		return
 	end
 
-	local buf = get_or_create_buffer()
-	local win_opts = get_position()
-
-	if state.state.status_bar.win and vim.api.nvim_win_is_valid(state.state.status_bar.win) then
-		vim.api.nvim_win_set_config(state.state.status_bar.win, win_opts)
-		render(buf)
-		return
-	end
-
-	local win = vim.api.nvim_open_win(buf, false, win_opts)
-
-	vim.wo[win].number = false
-	vim.wo[win].relativenumber = false
-	vim.wo[win].cursorline = false
-	vim.wo[win].signcolumn = "no"
-	vim.wo[win].winhighlight = "Normal:OrchestratorStatusBarBg,NormalFloat:OrchestratorStatusBarBg"
-
-	state.state.status_bar.win = win
-	render(buf)
+	local winbar_str = build_winbar_string()
+	apply_to_all_windows(winbar_str)
 end
 
---- Hide the status bar floating window
+--- Hide the winbar from all windows
 function M.hide()
-	if state.state.status_bar.win and vim.api.nvim_win_is_valid(state.state.status_bar.win) then
-		vim.api.nvim_win_close(state.state.status_bar.win, true)
-		state.state.status_bar.win = nil
-	end
+	apply_to_all_windows("")
 end
 
---- Update status bar (re-render and resize)
+--- Update the winbar (rebuild and reapply)
 --- Call this after instances change
 function M.update()
 	if instances.count() == 0 then
@@ -435,7 +249,7 @@ function M.update()
 	end
 end
 
---- Toggle status bar visibility
+--- Toggle winbar visibility
 function M.toggle()
 	state.state.status_bar.visible = not state.state.status_bar.visible
 
@@ -446,16 +260,33 @@ function M.toggle()
 	end
 end
 
---- Reposition status bar (call on VimResized)
-function M.reposition()
-	if state.state.status_bar.win and vim.api.nvim_win_is_valid(state.state.status_bar.win) then
-		local win_opts = get_position()
-		vim.api.nvim_win_set_config(state.state.status_bar.win, win_opts)
-
-		if state.state.status_bar.buf and vim.api.nvim_buf_is_valid(state.state.status_bar.buf) then
-			render(state.state.status_bar.buf)
-		end
+--- Apply winbar to a specific window (called from autocmd)
+--- @param win number Window ID to apply winbar to
+function M.apply_to_window(win)
+	if not state.state.status_bar.visible then
+		return
 	end
+
+	if instances.count() == 0 then
+		if vim.api.nvim_win_is_valid(win) then
+			vim.wo[win].winbar = ""
+		end
+		return
+	end
+
+	if should_apply_winbar(win) then
+		local winbar_str = build_winbar_string()
+		vim.wo[win].winbar = winbar_str
+	end
+end
+
+--- Get the current winbar string (for external use/debugging)
+--- @return string winbar_str The current winbar string
+function M.get_winbar_string()
+	if instances.count() == 0 or not state.state.status_bar.visible then
+		return ""
+	end
+	return build_winbar_string()
 end
 
 return M

--- a/lua/orchestrator/status_bar.lua
+++ b/lua/orchestrator/status_bar.lua
@@ -56,21 +56,15 @@ local function has_active_instance()
 		return false
 	end
 
-	-- Check if we're in a Claude terminal window
-	local in_claude_terminal = is_in_claude_terminal()
+	-- Only show active indicator when inside a Claude terminal
+	if not is_in_claude_terminal() then
+		return false
+	end
 
+	-- Check if current window matches any Claude instance
 	for _, inst in ipairs(all_instances) do
-		if in_claude_terminal then
-			-- In a Claude terminal: that terminal is active
-			if inst.win and vim.api.nvim_win_is_valid(inst.win) and inst.win == current_win then
-				return true
-			end
-		else
-			-- In any other window (editor, picker, floating, normal): use last_active_buf
-			local last_buf = state.state.last_active_buf
-			if last_buf and vim.api.nvim_buf_is_valid(last_buf) and inst.buf == last_buf then
-				return true
-			end
+		if inst.win and vim.api.nvim_win_is_valid(inst.win) and inst.win == current_win then
+			return true
 		end
 	end
 
@@ -160,7 +154,6 @@ local function render(buf)
 	end
 
 	-- Check if we're currently in a Claude terminal window
-	-- If not (editor, picker, any floating window, or normal window), use last_active_buf
 	local in_claude_terminal = is_in_claude_terminal()
 
 	local win_opts = get_position()
@@ -171,19 +164,11 @@ local function render(buf)
 	local byte_offset = 0 -- Track byte position for extmarks
 
 	for i, inst in ipairs(all_instances) do
-		local is_active
-		if in_claude_terminal then
-			-- In a Claude terminal: that terminal is active
-			is_active = inst.win
-				and vim.api.nvim_win_is_valid(inst.win)
-				and inst.win == current_win
-		else
-			-- In any other window: use last_active_buf to show contextually active instance
-			local last_buf = state.state.last_active_buf
-			is_active = last_buf
-				and vim.api.nvim_buf_is_valid(last_buf)
-				and inst.buf == last_buf
-		end
+		-- Only mark as active when inside a Claude terminal that matches this instance
+		local is_active = in_claude_terminal
+			and inst.win
+			and vim.api.nvim_win_is_valid(inst.win)
+			and inst.win == current_win
 
 		-- Bubble format: active gets wider padding for emphasis
 		local left_cap = config.bubble_left

--- a/lua/orchestrator/status_bar.lua
+++ b/lua/orchestrator/status_bar.lua
@@ -19,11 +19,21 @@ local config = {
 	-- Bubble effect separators (powerline rounded symbols)
 	bubble_left = "", -- U+E0B6 (left semicircle)
 	bubble_right = "", -- U+E0B4 (right semicircle)
+	-- Title display settings
+	title = {
+		max_length = 32, -- Maximum characters before truncation
+		ellipsis = "…", -- Truncation indicator (U+2026)
+		separator = " │ ", -- Between number and title (U+2502 thin vertical bar)
+		fallback = nil, -- Show when no title available (nil = number only)
+	},
 }
 
 -- Padding constants for bubble content
 local ACTIVE_PADDING = 2 -- spaces on each side for active bubble
 local INACTIVE_PADDING = 1 -- spaces on each side for inactive bubbles
+
+-- Shell names to filter out (before Claude sets actual title)
+local SHELL_NAMES = { "zsh", "bash", "fish", "sh", "dash", "ksh", "tcsh", "csh" }
 
 --- Check if the current window is a Claude terminal window
 --- @return boolean is_claude_win True if current window is a Claude terminal
@@ -40,6 +50,18 @@ local function is_in_claude_terminal()
 	end
 
 	return false
+end
+
+--- Check if a specific instance is currently active
+--- @param inst table Instance object with win field
+--- @param in_claude boolean Whether currently in a Claude terminal
+--- @param current_win number Current window ID
+--- @return boolean is_active True if this instance is active
+local function is_instance_active(inst, in_claude, current_win)
+	return in_claude
+		and inst.win
+		and vim.api.nvim_win_is_valid(inst.win)
+		and inst.win == current_win
 end
 
 --- Check if any Claude instance is currently active
@@ -71,32 +93,123 @@ local function has_active_instance()
 	return false
 end
 
---- Calculate the content width based on number of instances
---- Uses bubble format for active ( X ) and parentheses for inactive (X)
+--- Get and truncate the session title for an instance
+--- Reads vim.b.term_title at render time (Neovim maintains this via OSC 2)
+--- @param buf number Terminal buffer ID
+--- @return string|nil title The formatted title or nil if unavailable
+local function get_instance_title(buf)
+	-- Guard: validate buffer
+	if not buf or not vim.api.nvim_buf_is_valid(buf) then
+		return nil
+	end
+
+	-- Read term_title - Neovim populates this from OSC 2 sequences
+	local ok, title = pcall(vim.api.nvim_buf_get_var, buf, "term_title")
+	if not ok or not title or title == "" then
+		return nil
+	end
+
+	-- Filter out non-title values:
+	-- 1. Neovim terminal buffer names (term://path/to/dir//cmd)
+	-- 2. Common shell names or paths (before Claude sets the actual title)
+	if title:match("^term://") then
+		return nil
+	end
+	-- Match shell names as exact match or as basename of path (e.g., /bin/zsh)
+	local basename = title:match("([^/]+)$") or title
+	for _, shell in ipairs(SHELL_NAMES) do
+		if basename == shell then
+			return nil
+		end
+	end
+
+	-- Truncate if needed (with proper UTF-8 handling)
+	local display_width = vim.fn.strdisplaywidth(title)
+	if display_width > config.title.max_length then
+		local truncated = ""
+		local width = 0
+		-- UTF-8 aware iteration: matches single-byte ASCII or multi-byte sequences
+		for char in title:gmatch("[%z\1-\127\194-\244][\128-\191]*") do
+			local char_width = vim.fn.strdisplaywidth(char)
+			if width + char_width + vim.fn.strdisplaywidth(config.title.ellipsis) > config.title.max_length then
+				break
+			end
+			truncated = truncated .. char
+			width = width + char_width
+		end
+		return truncated .. config.title.ellipsis
+	end
+
+	return title
+end
+
+--- Calculate the content width based on number of instances and their titles
+--- Iterates through instances to sum variable widths (titles vary in length)
+--- @param all_instances table Array of instance objects
+--- @param title_cache table Map of buf -> title (cached lookups)
 --- @return number width Content width in display columns
-local function calculate_content_width()
-	local count = instances.count()
+local function calculate_content_width(all_instances, title_cache)
+	local count = #all_instances
 	if count == 0 then
 		return 0
 	end
 
-	-- Base bubble width (narrow format)
-	local bubble_width = vim.fn.strdisplaywidth(config.bubble_left .. " 9 " .. config.bubble_right)
+	local current_win = vim.api.nvim_get_current_win()
+	local in_claude = is_in_claude_terminal()
+	local total_width = 0
 
-	-- Only add extra width if an instance is actually active
-	local active_extra = has_active_instance() and (ACTIVE_PADDING - INACTIVE_PADDING) * 2 or 0
+	for i, inst in ipairs(all_instances) do
+		-- Determine if this instance is active (for padding calculation)
+		local is_active = is_instance_active(inst, in_claude, current_win)
+		local padding_size = is_active and ACTIVE_PADDING or INACTIVE_PADDING
 
-	-- Each agent is a bubble + space between (except last) + extra for active
-	local width = count * bubble_width + (count - 1) + active_extra
+		-- Calculate bubble content width: padding + number + (separator + title)? + padding
+		local content_width = padding_size -- left padding
+		content_width = content_width + vim.fn.strdisplaywidth(tostring(inst.number))
 
-	return width
+		local title = title_cache[inst.buf]
+		if title then
+			content_width = content_width + vim.fn.strdisplaywidth(config.title.separator)
+			content_width = content_width + vim.fn.strdisplaywidth(title)
+		elseif config.title.fallback then
+			content_width = content_width + vim.fn.strdisplaywidth(config.title.separator)
+			content_width = content_width + vim.fn.strdisplaywidth(config.title.fallback)
+		end
+
+		content_width = content_width + padding_size -- right padding
+
+		-- Add bubble caps
+		content_width = content_width + vim.fn.strdisplaywidth(config.bubble_left)
+		content_width = content_width + vim.fn.strdisplaywidth(config.bubble_right)
+
+		total_width = total_width + content_width
+
+		-- Add space between bubbles
+		if i < count then
+			total_width = total_width + 1
+		end
+	end
+
+	return total_width
 end
 
 --- Get window position for status bar
 --- Positioned just above lualine
+--- @param all_instances? table Array of instance objects (optional, fetched if nil)
+--- @param title_cache? table Map of buf -> title (optional, built if nil)
 --- @return table win_opts Window configuration
-local function get_position()
-	local content_width = calculate_content_width()
+local function get_position(all_instances, title_cache)
+	-- Fallback: fetch instances and build cache if not provided
+	if not all_instances then
+		all_instances = instances.get_all()
+	end
+	if not title_cache then
+		title_cache = {}
+		for _, inst in ipairs(all_instances) do
+			title_cache[inst.buf] = get_instance_title(inst.buf)
+		end
+	end
+	local content_width = calculate_content_width(all_instances, title_cache)
 	local max_width = math.floor(vim.o.columns * config.max_width_ratio)
 	local width = math.max(config.min_width, math.min(content_width + config.padding, max_width))
 
@@ -145,6 +258,12 @@ local function render(buf)
 		return
 	end
 
+	-- Cache titles once for both width calculation and rendering
+	local title_cache = {}
+	for _, inst in ipairs(all_instances) do
+		title_cache[inst.buf] = get_instance_title(inst.buf)
+	end
+
 	-- Detect active instance (the one in the current window)
 	local current_win = vim.api.nvim_get_current_win()
 
@@ -156,7 +275,7 @@ local function render(buf)
 	-- Check if we're currently in a Claude terminal window
 	local in_claude_terminal = is_in_claude_terminal()
 
-	local win_opts = get_position()
+	local win_opts = get_position(all_instances, title_cache)
 
 	-- Build parts and track highlight regions
 	local parts = {}
@@ -165,15 +284,25 @@ local function render(buf)
 
 	for i, inst in ipairs(all_instances) do
 		-- Only mark as active when inside a Claude terminal that matches this instance
-		local is_active = in_claude_terminal
-			and inst.win
-			and vim.api.nvim_win_is_valid(inst.win)
-			and inst.win == current_win
+		local is_active = is_instance_active(inst, in_claude_terminal, current_win)
 
 		-- Bubble format: active gets wider padding for emphasis
 		local left_cap = config.bubble_left
 		local padding = string.rep(" ", is_active and ACTIVE_PADDING or INACTIVE_PADDING)
-		local content = padding .. inst.number .. padding
+
+		-- Build content: number + (separator + title)?
+		local number_str = tostring(inst.number)
+		local title = title_cache[inst.buf]
+		local content
+
+		if title then
+			content = padding .. number_str .. config.title.separator .. title .. padding
+		elseif config.title.fallback then
+			content = padding .. number_str .. config.title.separator .. config.title.fallback .. padding
+		else
+			content = padding .. number_str .. padding
+		end
+
 		local right_cap = config.bubble_right
 
 		-- Add parts

--- a/lua/orchestrator/terminal.lua
+++ b/lua/orchestrator/terminal.lua
@@ -21,20 +21,21 @@ function M.set_instances(inst)
 end
 
 -- CLI command configurations for different spawn types
----@type table<string, {cmd: string, label: string, description: string}>
+-- Stores flags separately for cleaner command construction
+---@type table<string, {flags: string[], label: string, description: string}>
 M.spawn_types = {
 	fresh = {
-		cmd = "claude",
+		flags = {},
 		label = "New Claude",
 		description = "Start fresh conversation",
 	},
 	resume = {
-		cmd = "claude -r",
+		flags = { "-r" },
 		label = "Resume Claude",
 		description = "Resume last conversation",
 	},
 	continue = {
-		cmd = "claude -c",
+		flags = { "-c" },
 		label = "Continue Claude",
 		description = "Continue conversation",
 	},
@@ -77,25 +78,20 @@ function M.spawn(spawn_type, opts)
 
 	local cmd_config = M.spawn_types[spawn_type]
 
-	-- Build the command, optionally adding dangerous mode flag
-	-- Flag must come after 'claude' but before action flags (-r, -c)
-	local cmd
+	-- Build command from parts: claude [--dangerously-skip-permissions] [action-flags]
+	local cmd_parts = { "claude" }
 	if opts.dangerous then
-		cmd = "claude --dangerously-skip-permissions"
-		-- Append action flags if present (e.g., -r, -c)
-		local action_flags = cmd_config.cmd:match("^claude%s*(.*)")
-		if action_flags and action_flags ~= "" then
-			cmd = cmd .. " " .. action_flags
-		end
-	else
-		cmd = cmd_config.cmd
+		table.insert(cmd_parts, "--dangerously-skip-permissions")
 	end
+	for _, flag in ipairs(cmd_config.flags) do
+		table.insert(cmd_parts, flag)
+	end
+	local cmd = table.concat(cmd_parts, " ")
 
 	-- Verify CLI is installed before attempting to spawn
-	local cmd_name = cmd_config.cmd:match("^%S+")
-	if vim.fn.executable(cmd_name) == 0 then
+	if vim.fn.executable("claude") == 0 then
 		vim.notify(
-			string.format("Command '%s' not found. Is Claude CLI installed?", cmd_name),
+			"Command 'claude' not found. Is Claude CLI installed?",
 			vim.log.levels.ERROR
 		)
 		return nil

--- a/lua/orchestrator/terminal.lua
+++ b/lua/orchestrator/terminal.lua
@@ -59,14 +59,16 @@ end
 --- Spawn a new Claude terminal
 --- Creates buffer, opens terminal with specified variant, registers instance
 --- @param spawn_type string|nil "fresh" | "resume" | "continue" (defaults to "fresh")
+--- @param opts table|nil Options { dangerous = boolean }
 --- @return table|nil instance The created instance, or nil on failure
-function M.spawn(spawn_type)
+function M.spawn(spawn_type, opts)
 	-- Fail fast if dependencies aren't wired up
 	if not instances then
 		error("terminal.lua: instances module not initialized. Call set_instances() in setup.")
 	end
 
 	spawn_type = spawn_type or "fresh"
+	opts = opts or {}
 
 	if not M.is_valid_spawn_type(spawn_type) then
 		vim.notify("Unknown spawn type: " .. tostring(spawn_type), vim.log.levels.ERROR)
@@ -74,6 +76,20 @@ function M.spawn(spawn_type)
 	end
 
 	local cmd_config = M.spawn_types[spawn_type]
+
+	-- Build the command, optionally adding dangerous mode flag
+	-- Flag must come after 'claude' but before action flags (-r, -c)
+	local cmd
+	if opts.dangerous then
+		cmd = "claude --dangerously-skip-permissions"
+		-- Append action flags if present (e.g., -r, -c)
+		local action_flags = cmd_config.cmd:match("^claude%s*(.*)")
+		if action_flags and action_flags ~= "" then
+			cmd = cmd .. " " .. action_flags
+		end
+	else
+		cmd = cmd_config.cmd
+	end
 
 	-- Verify CLI is installed before attempting to spawn
 	local cmd_name = cmd_config.cmd:match("^%S+")
@@ -94,7 +110,7 @@ function M.spawn(spawn_type)
 	vim.api.nvim_set_current_buf(buf)
 
 	-- Spawn terminal with Claude command
-	local job_id = vim.fn.termopen(cmd_config.cmd, {
+	local job_id = vim.fn.termopen(cmd, {
 		cwd = cwd,
 		on_exit = function(_, exit_code, _)
 			vim.schedule(function()
@@ -117,7 +133,7 @@ function M.spawn(spawn_type)
 
 	vim.cmd("startinsert")
 
-	return instances.register_spawned(buf, job_id, cwd, spawn_type)
+	return instances.register_spawned(buf, job_id, cwd, spawn_type, opts.dangerous)
 end
 
 --- Focus an existing Claude terminal


### PR DESCRIPTION
## Summary

Migrates the status bar from a floating window implementation to Neovim's native `vim.wo.winbar` API. This simplifies the architecture by eliminating window management complexity while maintaining the same visual design with bubble-style instance indicators.

### Key Changes

- **Architecture**: Replace floating window with native winbar applied to all non-floating windows
- **Rendering**: Use statusline format syntax (`%#Highlight#text`) instead of extmarks
- **Active state**: Fixed bug where switching between Claude terminal splits didn't update the previously active window's highlighting
- **Cleanup**: Added timer cleanup to prevent stale callbacks after plugin reload
- **Code quality**: Removed dead code, added defensive validation, simplified logic

### Commits

| Commit | Description |
|--------|-------------|
| `3f360d5` | Initial migration from floating window to native winbar |
| `fc72880` | Fix winbar background transparency |
| `108319c` | Add bubble borders with powerline semicircles |
| `3cb7fec` | Fix critical bugs in autocmd and cleanup logic |
| `bbb3387` | Remove unused highlights, add color index validation |
| `4a27332` | Simplify active state logic and improve robustness |
| `f9329a1` | Update CLAUDE.md documentation |

## Test Plan

- [ ] Spawn 2+ Claude instances in splits, verify active indicator updates correctly when switching focus
- [ ] Run `:OrchestratorReload` during title updates, verify no errors
- [ ] Open quickfix/loclist/help windows, verify they don't get winbar
- [ ] Verify Claude terminal windows display winbar correctly
- [ ] Verify title truncation works with long session names